### PR TITLE
fix(mysql-docker.sh): use variable to get the path of executing file instead hardcoded path

### DIFF
--- a/mysql-docker.sh
+++ b/mysql-docker.sh
@@ -1,7 +1,8 @@
 #! /bin/sh
+SCRIPTPATH="$(cd "$(dirname "$0")";pwd -P)"
 docker run -d --name mysql -p 3306:3306 \
         -e MYSQL_ROOT_PASSWORD=ipl-mysql \
-        -v /data/development/ipl/tools/mysql/data:/var/lib/mysql \
-        -v /data/development/ipl/tools/mysql/conf:/etc/mysql/conf.d \
-        -v /data/development/ipl/tools/mysql/init:/docker-entrypoint-initdb.d \
+        -v $SCRIPTPATH/mysql/data:/var/lib/mysql \
+        -v $SCRIPTPATH/mysql/conf:/etc/mysql/conf.d \
+        -v $SCRIPTPATH/mysql/init:/docker-entrypoint-initdb.d \
         mysql


### PR DESCRIPTION
As we've discussed in classroom, we can replace the hardcoded path using some advantages of the bash scripting.

This solution, comes from: https://stackoverflow.com/a/4774063

I've tested on my local computer with two of possible situations, inside and outside the folder, and it created the docker container and executed the required script on `init` folder